### PR TITLE
refactor: unify dry-run with emit_file, update ruby/node versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -105,9 +105,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bstr"
@@ -140,9 +140,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -174,15 +174,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -195,13 +195,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys",
 ]
@@ -267,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "float-cmp"
@@ -285,6 +284,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -340,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -374,12 +397,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -405,16 +428,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -427,9 +452,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -460,9 +485,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -486,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -669,9 +694,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -736,6 +761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -809,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -826,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -933,11 +964,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -946,14 +977,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -964,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -974,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -987,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -1081,6 +1112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "zackstrap"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "zackstrap"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zackstrap"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 authors = ["Zack Kitzmiller"]
 description = "A CLI tool to bootstrap project configuration files"

--- a/justfile
+++ b/justfile
@@ -1,234 +1,261 @@
-# Zackstrap Project Justfile
-# Just is a command runner - https://github.com/casey/just
+# Zackstrap — project command runner
+# https://github.com/casey/just
+
+set dotenv-load := false
+
+version := `cargo get package.version 2>/dev/null || echo 'unknown'`
+os := `uname -s | tr '[:upper:]' '[:lower:]'`
+arch := `uname -m`
+
+# ─── Default ──────────────────────────────────────────────────────────
 
 default:
-  just info
+    @just --list --unsorted
 
-# Development
-rust-version:
-  just info
+# ─── Development ──────────────────────────────────────────────────────
 
-cargo-build:
-  cargo build
+# Build debug binary
+build:
+    cargo build
 
-cargo-build-release:
-  cargo build --release
+# Build optimized release binary
+build-release:
+    cargo build --release
 
-release-build:
-  @echo "Building release version..."
-  @if ! cargo get package.version >/dev/null 2>&1; then \
-    echo "cargo-get not found, installing tools..."; \
-    just install-tools; \
-  fi
-  @echo "Building version: $(cargo get package.version 2>/dev/null || echo 'unknown')"
-  cargo build --release
+# Install zackstrap to ~/.cargo/bin
+install:
+    cargo install --path .
 
-  @echo "Creating release directory..."
-  mkdir -p dist
+# Run the CLI with arguments (e.g. `just run -- ruby --template rails`)
+run *ARGS:
+    cargo run -- {{ARGS}}
 
-  @echo "Copying binary to dist/..."
-  cp target/release/zackstrap dist/
+# Watch for changes and rebuild on save
+watch:
+    cargo watch -x check -x 'test -- --nocapture'
 
-  @echo "Creating zipfile..."
-  cd dist && zip -r "zackstrap-$(cargo get package.version 2>/dev/null || echo 'unknown')-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m).zip" zackstrap
-  @echo "Release build complete!"
-  @echo "Zipfile: dist/zackstrap-$(cargo get package.version 2>/dev/null || echo 'unknown')-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m).zip"
-
-test:
-  cargo test
-
-test-e2e:
-  cargo test -p zackstrap --test e2e_tests
-
-test-coverage:
-  cargo install cargo-tarpaulin --version 0.32.8
-  cargo tarpaulin --out Html --output-directory coverage
-
+# Check compilation without producing binaries
 check:
-  cargo check
+    cargo check --all-targets --all-features
 
+# ─── Testing ──────────────────────────────────────────────────────────
+
+# Run all tests
+test:
+    cargo test
+
+# Run a single test by name
+test-one NAME:
+    cargo test {{NAME}} -- --nocapture
+
+# Run only unit tests
+test-unit:
+    cargo test -p zackstrap --test unit_tests
+
+# Run only integration tests
+test-integration:
+    cargo test -p zackstrap --test integration_tests
+
+# Run only CLI argument parsing tests
+test-cli:
+    cargo test -p zackstrap --test cli_tests
+
+# Run only end-to-end tests
+test-e2e:
+    cargo test -p zackstrap --test e2e_tests
+
+# Run only fail-on-exists tests
+test-fail-on-exists:
+    cargo test -p zackstrap --test fail_on_exists_tests
+
+# Run only generator tests
+test-generators:
+    cargo test -p zackstrap --test generators_tests
+
+# Run tests with stdout visible
+test-verbose:
+    cargo test -- --nocapture
+
+# Generate HTML coverage report via tarpaulin
+test-coverage:
+    cargo tarpaulin --out Html --output-directory coverage
+    @echo "Report: coverage/tarpaulin-report.html"
+
+# Generate coverage and fail if below threshold
+test-coverage-check THRESHOLD="80":
+    cargo tarpaulin --fail-under {{THRESHOLD}}
+
+# ─── Linting & Formatting ────────────────────────────────────────────
+
+# Format all source files
 fmt:
-  cargo fmt --all
+    cargo fmt --all
 
+# Check formatting without modifying files
 fmt-check:
-  cargo fmt --all -- --check
+    cargo fmt --all -- --check
 
+# Run clippy with warnings-as-errors
 clippy:
-  cargo clippy --all-targets --all-features -- -D warnings
+    cargo clippy --all-targets --all-features -- -D warnings
 
-clean:
-  cargo clean
+# Run clippy and auto-fix what it can
+clippy-fix:
+    cargo clippy --all-targets --all-features --fix --allow-dirty -- -D warnings
 
-# CI/CD Stages
-# Note: These commands require 'just' to be installed in CI
-# The CI workflows automatically install 'just' using taiki-e/install-action@just
-ci-lint-format:
-  @echo "Running lint and format checks..."
-  cargo fmt --all -- --check
-  cargo clippy --all-targets --all-features -- -D warnings
+# Lint everything (format check + clippy)
+lint: fmt-check clippy
 
+# Fix everything (format + clippy auto-fix)
+fix: fmt clippy-fix
+
+# ─── Security & Dependencies ─────────────────────────────────────────
+
+# Audit dependencies for known vulnerabilities
+audit:
+    cargo audit
+
+# Show outdated dependencies
+outdated:
+    cargo outdated
+
+# Show the full dependency tree
+deps:
+    cargo tree
+
+# Show duplicate dependencies
+deps-dupes:
+    cargo tree -d
+
+# Update all dependencies to latest compatible versions
+deps-update:
+    cargo update
+
+# ─── Pre-commit & CI ─────────────────────────────────────────────────
+
+# Quick pre-commit checks (format + clippy + check)
+pre-commit: fmt clippy check
+
+# Full local CI pipeline (lint + all tests)
+ci-local: lint test
+
+# CI lint stage (matches GitHub Actions)
+ci-lint:
+    @echo "CI: lint + format check"
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# CI test stage (matches GitHub Actions)
 ci-test:
-  @echo "Running tests and coverage..."
-  cargo test --all-features
-  cargo tarpaulin --out Xml --output-dir coverage
+    @echo "CI: tests + coverage"
+    cargo test --all-features
+    cargo tarpaulin --out Xml --output-dir coverage
 
-ci-local:
-  @echo "Running full local CI pipeline..."
-  just ci-lint-format
-  just ci-test
+# ─── Release ──────────────────────────────────────────────────────────
 
-# Quick checks
-quick-check:
-  @echo "Quick code check..."
-  cargo check --all-targets --all-features
+# Bump version, tag, push, and publish to crates.io
+release LEVEL:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "{{LEVEL}}" != "patch" && "{{LEVEL}}" != "minor" && "{{LEVEL}}" != "major" ]]; then
+        echo "Usage: just release [patch|minor|major]"
+        exit 1
+    fi
+    echo "Creating {{LEVEL}} release..."
+    cargo set-version --bump {{LEVEL}}
+    cargo check
+    git add Cargo.toml Cargo.lock
+    git commit -m "Bump version for {{LEVEL}} release"
+    VERSION="$(cargo get package.version)"
+    git tag -a "v${VERSION}" -m "Release v${VERSION}"
+    echo "Pushing to origin..."
+    git push origin main
+    git push origin "v${VERSION}"
+    echo "Publishing to crates.io..."
+    cargo publish
+    echo "Released v${VERSION}"
 
-quick-fmt:
-  @echo "Formatting code..."
-  cargo fmt --all
+# Build a distributable zipfile for the current platform
+dist:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Building release binary..."
+    cargo build --release
+    mkdir -p dist
+    cp target/release/zackstrap dist/
+    ZIPNAME="zackstrap-{{version}}-{{os}}-{{arch}}.zip"
+    cd dist && zip -r "$ZIPNAME" zackstrap
+    echo "dist/$ZIPNAME"
 
-quick-lint:
-  @echo "Running clippy..."
-  cargo clippy --all-targets --all-features -- -D warnings
+# Dry-run a crates.io publish (validates packaging without uploading)
+publish-dry-run:
+    cargo publish --dry-run
 
-# Pre-commit checks
-pre-commit:
-  @echo "Running pre-commit checks..."
-  just quick-fmt
-  just quick-lint
-  just quick-check
+# ─── Cleanup ──────────────────────────────────────────────────────────
 
-# Development tools
-install-tools:
-  @echo "Installing development tools..."
-  cargo install cargo-get || echo "cargo-get already installed"
-  cargo install cargo-set-version || echo "cargo-set-version already installed"
-  cargo install cargo-audit || echo "cargo-audit already installed"
-  cargo install cargo-outdated || echo "cargo-outdated already installed"
-  cargo install cargo-watch || echo "cargo-watch already installed"
-  cargo install cargo-tarpaulin --version 0.32.8 || echo "cargo-tarpaulin already installed"
+# Remove build artifacts
+clean:
+    cargo clean
 
+# Remove build artifacts and coverage reports
+clean-all: clean
+    rm -rf coverage dist
 
-check-deps:
-  @echo "Checking dependencies..."
-  cargo outdated || echo "Dependencies check completed (some may be outdated)"
+# ─── Project Info ─────────────────────────────────────────────────────
 
-check-deps-json:
-  @echo "Checking dependencies and saving to JSON..."
-  cargo outdated --format json > outdated-deps.json || echo "Dependencies check completed (some may be outdated)"
-  @echo "Results saved to outdated-deps.json"
-
-check-deps-table:
-  @echo "Checking dependencies in table format..."
-  cargo outdated --format list || echo "Dependencies check completed (some may be outdated)"
-
-check-tools:
-  @echo "Development Tools Status:"
-  @echo "========================"
-  @echo "cargo-get: $(cargo get --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-set-version: $(cargo set-version --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-audit: $(cargo audit --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-outdated: $(cargo outdated --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-watch: $(cargo watch --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-tarpaulin: $(cargo tarpaulin --version 2>/dev/null || echo 'not installed')"
-
-# Release
-release-patch:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  echo "Creating patch release..."
-  cargo set-version --bump patch
-  git add Cargo.toml Cargo.lock
-  git commit -m "Bump version for patch release"
-  if ! cargo get package.version >/dev/null 2>&1; then
-    echo "cargo-get not found, installing tools..."
-    just install-tools
-  fi
-  VERSION="$(cargo get package.version)"
-  git tag -a "v${VERSION}" -m "Release v${VERSION}"
-  git push origin main
-  git push origin "v${VERSION}"
-  cargo publish
-
-release-minor:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  echo "Creating minor release..."
-  cargo set-version --bump minor
-  git add Cargo.toml Cargo.lock
-  git commit -m "Bump version for minor release"
-  if ! cargo get package.version >/dev/null 2>&1; then
-    echo "cargo-get not found, installing tools..."
-    just install-tools
-  fi
-  VERSION="$(cargo get package.version)"
-  git tag -a "v${VERSION}" -m "Release v${VERSION}"
-  git push origin main
-  git push origin "v${VERSION}"
-  cargo publish
-
-release-major:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  echo "Creating major release..."
-  cargo set-version --bump major
-  git add Cargo.toml Cargo.lock
-  git commit -m "Bump version for major release"
-  if ! cargo get package.version >/dev/null 2>&1; then
-    echo "cargo-get not found, installing tools..."
-    just install-tools
-  fi
-  VERSION="$(cargo get package.version)"
-  git tag -a "v${VERSION}" -m "Release v${VERSION}"
-  git push origin main
-  git push origin "v${VERSION}"
-  cargo publish
-
-# Cache management (project/cargo only - never touches ~/.cargo/bin or ~/.local/bin)
-clear-cache:
-    @echo "Clearing project and cargo caches..."
-    @rm -rf target
-    @echo "✅ Project build cache (target/) cleared!"
-
-clear-cache-cargo:
-    @echo "Clearing cargo registry and project cache..."
-    @rm -rf ~/.cargo/registry ~/.cargo/git target
-    @echo "✅ Cargo cache cleared!"
-
-cache-status:
-    @echo "Cache Status"
-    @echo "============"
-    @echo "Cargo registry: $(du -sh ~/.cargo/registry 2>/dev/null || echo 'not found')"
-    @echo "Cargo git: $(du -sh ~/.cargo/git 2>/dev/null || echo 'not found')"
-    @echo "Target directory: $(du -sh target 2>/dev/null || echo 'not found')"
-    @echo "Cargo bin: $(du -sh ~/.cargo/bin 2>/dev/null || echo 'not found')"
-    @echo "Just bin: $(du -sh ~/.local/bin 2>/dev/null || echo 'not found')"
-    @echo ""
-    @echo "Development Tools:"
-    @echo "cargo-get: $(cargo get --version 2>/dev/null || echo 'not installed')"
-    @echo "cargo-set-version: $(cargo set-version --version 2>/dev/null || echo 'not installed')"
-    @echo "cargo-audit: $(cargo audit --version 2>/dev/null || echo 'not installed')"
-    @echo "cargo-outdated: $(cargo outdated --version 2>/dev/null || echo 'not installed')"
-    @echo "cargo-watch: $(cargo watch --version 2>/dev/null || echo 'not installed')"
-    @echo "cargo-tarpaulin: $(cargo tarpaulin --version 2>/dev/null || echo 'not installed')"
-
-# Project info
+# Show project and toolchain versions
 info:
-  @echo "Zackstrap Project Information"
-  @echo "============================"
-  @echo "Rust version: $(rustc --version)"
-  @echo "Cargo version: $(cargo --version)"
-  @echo "Just version: $(just --version)"
-  @if ! cargo get --version >/dev/null 2>&1; then \
-    echo "cargo-get not found, installing tools..."; \
-    just install-tools; \
-  fi
-  @echo "Current version: $(cargo get package.version 2>/dev/null || echo 'unknown')"
-  @echo ""
-  @echo "Development Tools Status:"
-  @echo "========================"
-  @echo "cargo-get: $(cargo get --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-set-version: $(cargo set-version --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-audit: $(cargo audit --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-outdated: $(cargo outdated --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-watch: $(cargo watch --version 2>/dev/null || echo 'not installed')"
-  @echo "cargo-tarpaulin: $(cargo tarpaulin --version 2>/dev/null || echo 'not installed')"
+    @echo "Zackstrap v{{version}}"
+    @echo ""
+    @echo "Toolchain"
+    @echo "  rustc:  $(rustc --version)"
+    @echo "  cargo:  $(cargo --version)"
+    @echo "  just:   $(just --version)"
+    @echo ""
+    @echo "Dev Tools"
+    @echo "  cargo-get:         $(cargo get --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-set-version: $(cargo set-version --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-audit:       $(cargo audit --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-outdated:    $(cargo outdated --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-watch:       $(cargo watch --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-tarpaulin:   $(cargo tarpaulin --version 2>/dev/null || echo 'not installed')"
+
+# Show lines of code
+loc:
+    @echo "Source:"
+    @find src -name '*.rs' | xargs wc -l | tail -1
+    @echo "Tests:"
+    @find tests -name '*.rs' | xargs wc -l | tail -1
+
+# Install all development tools
+install-tools:
+    cargo install cargo-get cargo-set-version cargo-audit cargo-outdated cargo-watch
+    cargo install cargo-tarpaulin --version 0.32.8
+
+# Show disk usage of build artifacts and caches
+cache-status:
+    @echo "Disk Usage"
+    @echo "  target/:         $(du -sh target 2>/dev/null | cut -f1 || echo 'n/a')"
+    @echo "  coverage/:       $(du -sh coverage 2>/dev/null | cut -f1 || echo 'n/a')"
+    @echo "  dist/:           $(du -sh dist 2>/dev/null | cut -f1 || echo 'n/a')"
+    @echo "  ~/.cargo/registry: $(du -sh ~/.cargo/registry 2>/dev/null | cut -f1 || echo 'n/a')"
+
+# ─── Dogfooding ───────────────────────────────────────────────────────
+
+# Generate configs into a temp directory (test the CLI output)
+try PROFILE="ruby" *ARGS="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DIR=$(mktemp -d)
+    echo "Target: $DIR"
+    cargo run -- --target "$DIR" {{PROFILE}} {{ARGS}}
+    echo ""
+    echo "Generated files:"
+    ls -la "$DIR"
+    echo ""
+    echo "Cleaning up..."
+    rm -rf "$DIR"
+
+# Dry-run a profile to preview output
+preview PROFILE="ruby" *ARGS="":
+    cargo run -- --dry-run {{PROFILE}} {{ARGS}}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -28,9 +28,13 @@ impl CommandHandler {
         }
     }
 
+    fn make_generator(&self) -> ConfigGenerator {
+        ConfigGenerator::with_options(self.target_dir.clone(), self.dry_run, self.force)
+    }
+
     pub async fn handle_basic(&self, template: Option<String>) -> Result<(), ZackstrapError> {
         let template_name = template.as_deref().unwrap_or("default");
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!(
@@ -41,14 +45,6 @@ impl CommandHandler {
                 )
                 .blue()
             );
-            generator.dry_run_basic_with_template(template_name).await?;
-
-            if self.hooks {
-                println!(
-                    "{}",
-                    "🪝 [DRY RUN] Would generate git hooks for basic project...".blue()
-                );
-            }
         } else {
             println!(
                 "{}",
@@ -58,9 +54,20 @@ impl CommandHandler {
                 )
                 .green()
             );
-            generator
-                .generate_basic_with_template(self.force, self.fail_on_exists, template_name)
-                .await?;
+        }
+
+        generator
+            .generate_basic_with_template(self.fail_on_exists, template_name)
+            .await?;
+
+        if self.dry_run {
+            if self.hooks {
+                println!(
+                    "{}",
+                    "🪝 [DRY RUN] Would generate git hooks for basic project...".blue()
+                );
+            }
+        } else {
             println!(
                 "{}",
                 "✅ Basic configuration files generated successfully!".green()
@@ -78,7 +85,7 @@ impl CommandHandler {
 
     pub async fn handle_ruby(&self, template: Option<String>) -> Result<(), ZackstrapError> {
         let template_name = template.as_deref().unwrap_or("default");
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!(
@@ -89,8 +96,22 @@ impl CommandHandler {
                 )
                 .blue()
             );
-            generator.dry_run_ruby_with_template(template_name).await?;
+        } else {
+            println!(
+                "{}",
+                format!(
+                    "💎 Generating Ruby project configuration (template: {})...",
+                    template_name
+                )
+                .green()
+            );
+        }
 
+        generator
+            .generate_ruby_with_template(template_name)
+            .await?;
+
+        if self.dry_run {
             if self.hooks {
                 println!(
                     "{}",
@@ -102,17 +123,6 @@ impl CommandHandler {
                 );
             }
         } else {
-            println!(
-                "{}",
-                format!(
-                    "💎 Generating Ruby project configuration (template: {})...",
-                    template_name
-                )
-                .green()
-            );
-            generator
-                .generate_ruby_with_template(self.force, template_name)
-                .await?;
             println!(
                 "{}",
                 "✅ Ruby configuration files generated successfully!".green()
@@ -139,7 +149,7 @@ impl CommandHandler {
 
     pub async fn handle_python(&self, template: Option<String>) -> Result<(), ZackstrapError> {
         let template_name = template.as_deref().unwrap_or("default");
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!(
@@ -150,10 +160,22 @@ impl CommandHandler {
                 )
                 .blue()
             );
-            generator
-                .dry_run_python_with_template(template_name)
-                .await?;
+        } else {
+            println!(
+                "{}",
+                format!(
+                    "🐍 Generating Python project configuration (template: {})...",
+                    template_name
+                )
+                .green()
+            );
+        }
 
+        generator
+            .generate_python_with_template(template_name)
+            .await?;
+
+        if self.dry_run {
             if self.hooks {
                 println!(
                     "{}",
@@ -164,17 +186,6 @@ impl CommandHandler {
                 );
             }
         } else {
-            println!(
-                "{}",
-                format!(
-                    "🐍 Generating Python project configuration (template: {})...",
-                    template_name
-                )
-                .green()
-            );
-            generator
-                .generate_python_with_template(self.force, template_name)
-                .await?;
             println!(
                 "{}",
                 "✅ Python configuration files generated successfully!".green()
@@ -201,7 +212,7 @@ impl CommandHandler {
 
     pub async fn handle_node(&self, template: Option<String>) -> Result<(), ZackstrapError> {
         let template_name = template.as_deref().unwrap_or("default");
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!(
@@ -212,8 +223,22 @@ impl CommandHandler {
                 )
                 .blue()
             );
-            generator.dry_run_node_with_template(template_name).await?;
+        } else {
+            println!(
+                "{}",
+                format!(
+                    "🟢 Generating Node.js project configuration (template: {})...",
+                    template_name
+                )
+                .green()
+            );
+        }
 
+        generator
+            .generate_node_with_template(template_name)
+            .await?;
+
+        if self.dry_run {
             if self.hooks {
                 println!(
                     "{}",
@@ -224,17 +249,6 @@ impl CommandHandler {
                 );
             }
         } else {
-            println!(
-                "{}",
-                format!(
-                    "🟢 Generating Node.js project configuration (template: {})...",
-                    template_name
-                )
-                .green()
-            );
-            generator
-                .generate_node_with_template(self.force, template_name)
-                .await?;
             println!(
                 "{}",
                 "✅ Node.js configuration files generated successfully!".green()
@@ -261,7 +275,7 @@ impl CommandHandler {
 
     pub async fn handle_go(&self, template: Option<String>) -> Result<(), ZackstrapError> {
         let template_name = template.as_deref().unwrap_or("default");
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!(
@@ -272,8 +286,22 @@ impl CommandHandler {
                 )
                 .blue()
             );
-            generator.dry_run_go_with_template(template_name).await?;
+        } else {
+            println!(
+                "{}",
+                format!(
+                    "🐹 Generating Go project configuration (template: {})...",
+                    template_name
+                )
+                .green()
+            );
+        }
 
+        generator
+            .generate_go_with_template(template_name)
+            .await?;
+
+        if self.dry_run {
             if self.hooks {
                 println!(
                     "{}",
@@ -285,17 +313,6 @@ impl CommandHandler {
                 );
             }
         } else {
-            println!(
-                "{}",
-                format!(
-                    "🐹 Generating Go project configuration (template: {})...",
-                    template_name
-                )
-                .green()
-            );
-            generator
-                .generate_go_with_template(self.force, template_name)
-                .await?;
             println!(
                 "{}",
                 "✅ Go configuration files generated successfully!".green()
@@ -322,7 +339,7 @@ impl CommandHandler {
 
     pub async fn handle_rust(&self, template: Option<String>) -> Result<(), ZackstrapError> {
         let template_name = template.as_deref().unwrap_or("default");
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!(
@@ -333,8 +350,22 @@ impl CommandHandler {
                 )
                 .blue()
             );
-            generator.dry_run_rust_with_template(template_name).await?;
+        } else {
+            println!(
+                "{}",
+                format!(
+                    "🦀 Generating Rust project configuration (template: {})...",
+                    template_name
+                )
+                .green()
+            );
+        }
 
+        generator
+            .generate_rust_with_template(template_name)
+            .await?;
+
+        if self.dry_run {
             if self.hooks {
                 println!(
                     "{}",
@@ -346,17 +377,6 @@ impl CommandHandler {
                 );
             }
         } else {
-            println!(
-                "{}",
-                format!(
-                    "🦀 Generating Rust project configuration (template: {})...",
-                    template_name
-                )
-                .green()
-            );
-            generator
-                .generate_rust_with_template(self.force, template_name)
-                .await?;
             println!(
                 "{}",
                 "✅ Rust configuration files generated successfully!".green()
@@ -383,7 +403,7 @@ impl CommandHandler {
 
     pub async fn handle_bash(&self, template: Option<String>) -> Result<(), ZackstrapError> {
         let template_name = template.as_deref().unwrap_or("default");
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!(
@@ -394,8 +414,22 @@ impl CommandHandler {
                 )
                 .blue()
             );
-            generator.dry_run_bash_with_template(template_name).await?;
+        } else {
+            println!(
+                "{}",
+                format!(
+                    "🐚 Generating Bash project configuration (template: {})...",
+                    template_name
+                )
+                .green()
+            );
+        }
 
+        generator
+            .generate_bash_with_template(template_name)
+            .await?;
+
+        if self.dry_run {
             if self.hooks {
                 println!(
                     "{}",
@@ -407,17 +441,6 @@ impl CommandHandler {
                 );
             }
         } else {
-            println!(
-                "{}",
-                format!(
-                    "🐚 Generating Bash project configuration (template: {})...",
-                    template_name
-                )
-                .green()
-            );
-            generator
-                .generate_bash_with_template(self.force, template_name)
-                .await?;
             println!(
                 "{}",
                 "✅ Bash configuration files generated successfully!".green()
@@ -443,76 +466,16 @@ impl CommandHandler {
     }
 
     pub async fn handle_auto(&self) -> Result<(), ZackstrapError> {
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
 
         if self.dry_run {
             println!("{}", "🔍 [DRY RUN] Auto-detecting project type...".blue());
-            let project_type = generator.detect_project_type().await?;
-            self.handle_auto_dry_run(project_type, &generator).await?;
         } else {
             println!("{}", "🔍 Auto-detecting project type...".blue());
-            let project_type = generator.detect_project_type().await?;
-            self.handle_auto_generate(project_type, &generator).await?;
         }
-        Ok(())
-    }
 
-    async fn handle_auto_dry_run(
-        &self,
-        project_type: ProjectType,
-        generator: &ConfigGenerator,
-    ) -> Result<(), ZackstrapError> {
-        match project_type {
-            ProjectType::Ruby => {
-                println!(
-                    "{}",
-                    "💎 [DRY RUN] Would generate Ruby project configuration...".blue()
-                );
-                generator.dry_run_ruby_with_template("default").await?;
-            }
-            ProjectType::Python => {
-                println!(
-                    "{}",
-                    "🐍 [DRY RUN] Would generate Python project configuration...".blue()
-                );
-                generator.dry_run_python_with_template("default").await?;
-            }
-            ProjectType::Node => {
-                println!(
-                    "{}",
-                    "🟢 [DRY RUN] Would generate Node.js project configuration...".blue()
-                );
-                generator.dry_run_node_with_template("default").await?;
-            }
-            ProjectType::Go => {
-                println!(
-                    "{}",
-                    "🐹 [DRY RUN] Would generate Go project configuration...".blue()
-                );
-                generator.dry_run_go_with_template("default").await?;
-            }
-            ProjectType::Rust => {
-                println!(
-                    "{}",
-                    "🦀 [DRY RUN] Would generate Rust project configuration...".blue()
-                );
-                generator.dry_run_rust_with_template("default").await?;
-            }
-            ProjectType::Bash => {
-                println!(
-                    "{}",
-                    "🐚 [DRY RUN] Would generate Bash project configuration...".blue()
-                );
-                generator.dry_run_bash_with_template("default").await?;
-            }
-            ProjectType::Basic => {
-                println!(
-                    "{}",
-                    "📁 [DRY RUN] Would generate basic project configuration...".blue()
-                );
-                generator.dry_run_basic_with_template("default").await?;
-            }
-        }
+        let project_type = generator.detect_project_type().await?;
+        self.handle_auto_generate(project_type, &generator).await?;
         Ok(())
     }
 
@@ -523,95 +486,158 @@ impl CommandHandler {
     ) -> Result<(), ZackstrapError> {
         match project_type {
             ProjectType::Ruby => {
-                println!(
-                    "{}",
-                    "💎 Detected Ruby project, generating configuration...".green()
-                );
+                if self.dry_run {
+                    println!(
+                        "{}",
+                        "💎 [DRY RUN] Would generate Ruby project configuration...".blue()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "💎 Detected Ruby project, generating configuration...".green()
+                    );
+                }
                 generator
-                    .generate_ruby_with_template(self.force, "default")
+                    .generate_ruby_with_template("default")
                     .await?;
-                println!(
-                    "{}",
-                    "✅ Ruby configuration files generated successfully!".green()
-                );
+                if !self.dry_run {
+                    println!(
+                        "{}",
+                        "✅ Ruby configuration files generated successfully!".green()
+                    );
+                }
             }
             ProjectType::Python => {
-                println!(
-                    "{}",
-                    "🐍 Detected Python project, generating configuration...".green()
-                );
+                if self.dry_run {
+                    println!(
+                        "{}",
+                        "🐍 [DRY RUN] Would generate Python project configuration...".blue()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "🐍 Detected Python project, generating configuration...".green()
+                    );
+                }
                 generator
-                    .generate_python_with_template(self.force, "default")
+                    .generate_python_with_template("default")
                     .await?;
-                println!(
-                    "{}",
-                    "✅ Python configuration files generated successfully!".green()
-                );
+                if !self.dry_run {
+                    println!(
+                        "{}",
+                        "✅ Python configuration files generated successfully!".green()
+                    );
+                }
             }
             ProjectType::Node => {
-                println!(
-                    "{}",
-                    "🟢 Detected Node.js project, generating configuration...".green()
-                );
+                if self.dry_run {
+                    println!(
+                        "{}",
+                        "🟢 [DRY RUN] Would generate Node.js project configuration...".blue()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "🟢 Detected Node.js project, generating configuration...".green()
+                    );
+                }
                 generator
-                    .generate_node_with_template(self.force, "default")
+                    .generate_node_with_template("default")
                     .await?;
-                println!(
-                    "{}",
-                    "✅ Node.js configuration files generated successfully!".green()
-                );
+                if !self.dry_run {
+                    println!(
+                        "{}",
+                        "✅ Node.js configuration files generated successfully!".green()
+                    );
+                }
             }
             ProjectType::Go => {
-                println!(
-                    "{}",
-                    "🐹 Detected Go project, generating configuration...".green()
-                );
+                if self.dry_run {
+                    println!(
+                        "{}",
+                        "🐹 [DRY RUN] Would generate Go project configuration...".blue()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "🐹 Detected Go project, generating configuration...".green()
+                    );
+                }
                 generator
-                    .generate_go_with_template(self.force, "default")
+                    .generate_go_with_template("default")
                     .await?;
-                println!(
-                    "{}",
-                    "✅ Go configuration files generated successfully!".green()
-                );
+                if !self.dry_run {
+                    println!(
+                        "{}",
+                        "✅ Go configuration files generated successfully!".green()
+                    );
+                }
             }
             ProjectType::Rust => {
-                println!(
-                    "{}",
-                    "🦀 Detected Rust project, generating configuration...".green()
-                );
+                if self.dry_run {
+                    println!(
+                        "{}",
+                        "🦀 [DRY RUN] Would generate Rust project configuration...".blue()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "🦀 Detected Rust project, generating configuration...".green()
+                    );
+                }
                 generator
-                    .generate_rust_with_template(self.force, "default")
+                    .generate_rust_with_template("default")
                     .await?;
-                println!(
-                    "{}",
-                    "✅ Rust configuration files generated successfully!".green()
-                );
+                if !self.dry_run {
+                    println!(
+                        "{}",
+                        "✅ Rust configuration files generated successfully!".green()
+                    );
+                }
             }
             ProjectType::Bash => {
-                println!(
-                    "{}",
-                    "🐚 Detected Bash project, generating configuration...".green()
-                );
+                if self.dry_run {
+                    println!(
+                        "{}",
+                        "🐚 [DRY RUN] Would generate Bash project configuration...".blue()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "🐚 Detected Bash project, generating configuration...".green()
+                    );
+                }
                 generator
-                    .generate_bash_with_template(self.force, "default")
+                    .generate_bash_with_template("default")
                     .await?;
-                println!(
-                    "{}",
-                    "✅ Bash configuration files generated successfully!".green()
-                );
+                if !self.dry_run {
+                    println!(
+                        "{}",
+                        "✅ Bash configuration files generated successfully!".green()
+                    );
+                }
             }
             ProjectType::Basic => {
-                println!(
-                    "{}",
-                    "📁 Detected basic project, generating configuration...".green()
-                );
+                if self.dry_run {
+                    println!(
+                        "{}",
+                        "📁 [DRY RUN] Would generate basic project configuration...".blue()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "📁 Detected basic project, generating configuration...".green()
+                    );
+                }
                 generator
-                    .generate_basic(self.force, self.fail_on_exists)
+                    .generate_basic(self.fail_on_exists)
                     .await?;
-                println!(
-                    "{}",
-                    "✅ Basic configuration files generated successfully!".green()
-                );
+                if !self.dry_run {
+                    println!(
+                        "{}",
+                        "✅ Basic configuration files generated successfully!".green()
+                    );
+                }
             }
         }
         Ok(())
@@ -627,7 +653,7 @@ impl CommandHandler {
             return Ok(());
         }
 
-        let generator = ConfigGenerator::new(self.target_dir.clone());
+        let generator = self.make_generator();
         println!("{}", "🎯 Interactive configuration setup...".blue());
         generator.interactive_setup().await?;
         Ok(())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -107,9 +107,7 @@ impl CommandHandler {
             );
         }
 
-        generator
-            .generate_ruby_with_template(template_name)
-            .await?;
+        generator.generate_ruby_with_template(template_name).await?;
 
         if self.dry_run {
             if self.hooks {
@@ -234,9 +232,7 @@ impl CommandHandler {
             );
         }
 
-        generator
-            .generate_node_with_template(template_name)
-            .await?;
+        generator.generate_node_with_template(template_name).await?;
 
         if self.dry_run {
             if self.hooks {
@@ -297,9 +293,7 @@ impl CommandHandler {
             );
         }
 
-        generator
-            .generate_go_with_template(template_name)
-            .await?;
+        generator.generate_go_with_template(template_name).await?;
 
         if self.dry_run {
             if self.hooks {
@@ -361,9 +355,7 @@ impl CommandHandler {
             );
         }
 
-        generator
-            .generate_rust_with_template(template_name)
-            .await?;
+        generator.generate_rust_with_template(template_name).await?;
 
         if self.dry_run {
             if self.hooks {
@@ -425,9 +417,7 @@ impl CommandHandler {
             );
         }
 
-        generator
-            .generate_bash_with_template(template_name)
-            .await?;
+        generator.generate_bash_with_template(template_name).await?;
 
         if self.dry_run {
             if self.hooks {
@@ -497,9 +487,7 @@ impl CommandHandler {
                         "💎 Detected Ruby project, generating configuration...".green()
                     );
                 }
-                generator
-                    .generate_ruby_with_template("default")
-                    .await?;
+                generator.generate_ruby_with_template("default").await?;
                 if !self.dry_run {
                     println!(
                         "{}",
@@ -519,9 +507,7 @@ impl CommandHandler {
                         "🐍 Detected Python project, generating configuration...".green()
                     );
                 }
-                generator
-                    .generate_python_with_template("default")
-                    .await?;
+                generator.generate_python_with_template("default").await?;
                 if !self.dry_run {
                     println!(
                         "{}",
@@ -541,9 +527,7 @@ impl CommandHandler {
                         "🟢 Detected Node.js project, generating configuration...".green()
                     );
                 }
-                generator
-                    .generate_node_with_template("default")
-                    .await?;
+                generator.generate_node_with_template("default").await?;
                 if !self.dry_run {
                     println!(
                         "{}",
@@ -563,9 +547,7 @@ impl CommandHandler {
                         "🐹 Detected Go project, generating configuration...".green()
                     );
                 }
-                generator
-                    .generate_go_with_template("default")
-                    .await?;
+                generator.generate_go_with_template("default").await?;
                 if !self.dry_run {
                     println!(
                         "{}",
@@ -585,9 +567,7 @@ impl CommandHandler {
                         "🦀 Detected Rust project, generating configuration...".green()
                     );
                 }
-                generator
-                    .generate_rust_with_template("default")
-                    .await?;
+                generator.generate_rust_with_template("default").await?;
                 if !self.dry_run {
                     println!(
                         "{}",
@@ -607,9 +587,7 @@ impl CommandHandler {
                         "🐚 Detected Bash project, generating configuration...".green()
                     );
                 }
-                generator
-                    .generate_bash_with_template("default")
-                    .await?;
+                generator.generate_bash_with_template("default").await?;
                 if !self.dry_run {
                     println!(
                         "{}",
@@ -629,9 +607,7 @@ impl CommandHandler {
                         "📁 Detected basic project, generating configuration...".green()
                     );
                 }
-                generator
-                    .generate_basic(self.fail_on_exists)
-                    .await?;
+                generator.generate_basic(self.fail_on_exists).await?;
                 if !self.dry_run {
                     println!(
                         "{}",

--- a/src/generators/bash.rs
+++ b/src/generators/bash.rs
@@ -1,40 +1,28 @@
-use super::common::FileGenerator;
 use crate::error::ZackstrapError;
 
 impl super::ConfigGenerator {
     #[allow(dead_code)]
-    pub async fn generate_bash(&self, force: bool) -> Result<(), ZackstrapError> {
-        self.generate_bash_with_template(force, "default").await
+    pub async fn generate_bash(&self) -> Result<(), ZackstrapError> {
+        self.generate_bash_with_template("default").await
     }
 
     pub async fn generate_bash_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         // Generate basic configs first
-        self.generate_basic_with_template(force, false, template)
-            .await?;
+        self.generate_basic_with_template(false, template).await?;
 
         // Generate Bash-specific configs
-        self.generate_shellcheck_config(force).await?;
+        self.generate_shellcheck_config().await?;
 
         // Overwrite the basic justfile with Bash-specific one
-        self.generate_bash_justfile(true, template).await?;
+        self.generate_bash_justfile(template).await?;
 
         Ok(())
     }
 
-    pub async fn dry_run_bash_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
-        println!("  📝 Would generate .editorconfig");
-        println!("  🎨 Would generate .prettierrc (template: {})", template);
-        println!("  🔧 Would generate justfile");
-        println!("  🔍 Would generate .shellcheckrc");
-        println!("  🔧 Would generate Bash justfile (template: {})", template);
-        Ok(())
-    }
-
-    async fn generate_shellcheck_config(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_shellcheck_config(&self) -> Result<(), ZackstrapError> {
         let content = r#"# ShellCheck configuration
 # See https://www.shellcheck.net/wiki/
 
@@ -51,15 +39,10 @@ enable=require-variable-braces
 enable=deprecate-which
 enable=avoid-nullary-conditions
 "#;
-        self.write_file_if_not_exists(".shellcheckrc", content, force, false)
-            .await
+        self.emit_file(".shellcheckrc", content, false, false).await
     }
 
-    async fn generate_bash_justfile(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_bash_justfile(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "devops" => {
                 r#"# Bash DevOps project justfile
@@ -173,7 +156,6 @@ check:
 "#
             }
         };
-        self.write_file_if_not_exists("justfile", content, force, false)
-            .await
+        self.emit_file("justfile", content, false, true).await
     }
 }

--- a/src/generators/bash.rs
+++ b/src/generators/bash.rs
@@ -6,10 +6,7 @@ impl super::ConfigGenerator {
         self.generate_bash_with_template("default").await
     }
 
-    pub async fn generate_bash_with_template(
-        &self,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    pub async fn generate_bash_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
         // Generate basic configs first
         self.generate_basic_with_template(false, template).await?;
 

--- a/src/generators/basic.rs
+++ b/src/generators/basic.rs
@@ -1,66 +1,26 @@
-use super::common::FileGenerator;
 use crate::config::{EditorConfig, PrettierConfig};
 use crate::error::ZackstrapError;
 
 impl super::ConfigGenerator {
-    pub async fn generate_basic(
-        &self,
-        force: bool,
-        fail_on_exists: bool,
-    ) -> Result<(), ZackstrapError> {
-        self.generate_basic_with_template(force, fail_on_exists, "default")
+    pub async fn generate_basic(&self, fail_on_exists: bool) -> Result<(), ZackstrapError> {
+        self.generate_basic_with_template(fail_on_exists, "default")
             .await
     }
 
     pub async fn generate_basic_with_template(
         &self,
-        force: bool,
         fail_on_exists: bool,
         template: &str,
-    ) -> Result<(), ZackstrapError> {
-        self.generate_editor_config(force, fail_on_exists).await?;
-        self.generate_prettier_config_with_template(force, fail_on_exists, template)
-            .await?;
-        self.generate_justfile(force, fail_on_exists).await?;
-        Ok(())
-    }
-
-    pub async fn dry_run_basic_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
-        println!("  📝 Would generate .editorconfig");
-        println!("  🎨 Would generate .prettierrc (template: {})", template);
-        println!("  🔧 Would generate justfile");
-        Ok(())
-    }
-
-    pub async fn generate_editor_config(
-        &self,
-        force: bool,
-        fail_on_exists: bool,
     ) -> Result<(), ZackstrapError> {
         let config = EditorConfig::default();
-        let content = config.to_string();
-        self.write_file_if_not_exists(".editorconfig", &content, force, fail_on_exists)
-            .await
-    }
+        self.emit_file(".editorconfig", &config.to_string(), fail_on_exists, false)
+            .await?;
 
-    async fn generate_prettier_config_with_template(
-        &self,
-        force: bool,
-        fail_on_exists: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
-        let config = PrettierConfig::from_template(template);
-        let content = config.to_string();
-        self.write_file_if_not_exists(".prettierrc", &content, force, fail_on_exists)
-            .await
-    }
+        let prettier = PrettierConfig::from_template(template);
+        self.emit_file(".prettierrc", &prettier.to_string(), fail_on_exists, false)
+            .await?;
 
-    async fn generate_justfile(
-        &self,
-        force: bool,
-        fail_on_exists: bool,
-    ) -> Result<(), ZackstrapError> {
-        let content = r#"# Basic project justfile
+        let justfile_content = r#"# Basic project justfile
 # Add your project-specific commands here
 
 # Default target
@@ -84,7 +44,16 @@ build:
 clean:
     @echo "Cleaning build artifacts..."
 "#;
-        self.write_file_if_not_exists("justfile", content, force, fail_on_exists)
+        self.emit_file("justfile", justfile_content, fail_on_exists, false)
+            .await?;
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub async fn generate_editor_config(&self, fail_on_exists: bool) -> Result<(), ZackstrapError> {
+        let config = EditorConfig::default();
+        self.emit_file(".editorconfig", &config.to_string(), fail_on_exists, false)
             .await
     }
 }

--- a/src/generators/common.rs
+++ b/src/generators/common.rs
@@ -40,3 +40,44 @@ impl FileGenerator for super::ConfigGenerator {
         &self.target_dir
     }
 }
+
+impl super::ConfigGenerator {
+    pub async fn emit_file(
+        &self,
+        filename: &str,
+        content: &str,
+        fail_on_exists: bool,
+        force_override: bool,
+    ) -> Result<(), ZackstrapError> {
+        use colored::*;
+
+        if self.dry_run {
+            let file_path = self.target_dir.join(filename);
+            let effective_force = self.force || force_override;
+
+            if file_path.exists() {
+                if effective_force {
+                    println!("  {} {}", "[OVERWRITE]".yellow(), filename);
+                } else {
+                    println!("  {} {} (already exists)", "[SKIP]".dimmed(), filename);
+                    return Ok(());
+                }
+            } else {
+                println!("  {} {}", "[CREATE]".green(), filename);
+            }
+
+            println!("  {}", "───────────────────────".dimmed());
+            for line in content.lines() {
+                println!("  {}", line.dimmed());
+            }
+            println!("  {}", "───────────────────────".dimmed());
+            println!();
+
+            return Ok(());
+        }
+
+        let effective_force = self.force || force_override;
+        self.write_file_if_not_exists(filename, content, effective_force, fail_on_exists)
+            .await
+    }
+}

--- a/src/generators/go.rs
+++ b/src/generators/go.rs
@@ -1,44 +1,30 @@
-use super::common::FileGenerator;
 use crate::error::ZackstrapError;
 
 impl super::ConfigGenerator {
     #[allow(dead_code)]
-    pub async fn generate_go(&self, force: bool) -> Result<(), ZackstrapError> {
-        self.generate_go_with_template(force, "default").await
+    pub async fn generate_go(&self) -> Result<(), ZackstrapError> {
+        self.generate_go_with_template("default").await
     }
 
     pub async fn generate_go_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         // Generate basic configs first
-        self.generate_basic_with_template(force, false, template)
-            .await?;
+        self.generate_basic_with_template(false, template).await?;
 
         // Generate Go-specific configs
-        self.generate_go_mod(force).await?;
-        self.generate_golangci_config(force).await?;
-        self.generate_go_gitignore(force).await?;
+        self.generate_go_mod().await?;
+        self.generate_golangci_config().await?;
+        self.generate_go_gitignore().await?;
 
         // Overwrite the basic justfile with Go-specific one
-        self.generate_go_justfile(true, template).await?;
+        self.generate_go_justfile(template).await?;
 
         Ok(())
     }
 
-    pub async fn dry_run_go_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
-        println!("  📝 Would generate .editorconfig");
-        println!("  🎨 Would generate .prettierrc (template: {})", template);
-        println!("  🔧 Would generate justfile");
-        println!("  🐹 Would generate go.mod");
-        println!("  🔍 Would generate .golangci.yml");
-        println!("  🚫 Would generate .gitignore");
-        println!("  🔧 Would generate Go justfile (template: {})", template);
-        Ok(())
-    }
-
-    async fn generate_go_mod(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_go_mod(&self) -> Result<(), ZackstrapError> {
         let content = r#"module myproject
 
 go 1.21
@@ -47,11 +33,10 @@ require (
 	// Add your Go dependencies here
 )
 "#;
-        self.write_file_if_not_exists("go.mod", content, force, false)
-            .await
+        self.emit_file("go.mod", content, false, false).await
     }
 
-    async fn generate_golangci_config(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_golangci_config(&self) -> Result<(), ZackstrapError> {
         let content = r#"run:
   timeout: 5m
   modules-download-mode: readonly
@@ -96,11 +81,10 @@ issues:
         - goconst
         - gosec
 "#;
-        self.write_file_if_not_exists(".golangci.yml", content, force, false)
-            .await
+        self.emit_file(".golangci.yml", content, false, false).await
     }
 
-    async fn generate_go_gitignore(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_go_gitignore(&self) -> Result<(), ZackstrapError> {
         let content = r#"# Binaries for programs and plugins
 *.exe
 *.exe~
@@ -145,15 +129,10 @@ go-mod-cache/
 ehthumbs.db
 Thumbs.db
 "#;
-        self.write_file_if_not_exists(".gitignore", content, force, false)
-            .await
+        self.emit_file(".gitignore", content, false, false).await
     }
 
-    async fn generate_go_justfile(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_go_justfile(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "web" => {
                 r#"# Go web project justfile
@@ -288,7 +267,6 @@ install:
 "#
             }
         };
-        self.write_file_if_not_exists("justfile", content, force, false)
-            .await
+        self.emit_file("justfile", content, false, true).await
     }
 }

--- a/src/generators/go.rs
+++ b/src/generators/go.rs
@@ -6,10 +6,7 @@ impl super::ConfigGenerator {
         self.generate_go_with_template("default").await
     }
 
-    pub async fn generate_go_with_template(
-        &self,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    pub async fn generate_go_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
         // Generate basic configs first
         self.generate_basic_with_template(false, template).await?;
 

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -25,11 +25,26 @@ pub enum ProjectType {
 
 pub struct ConfigGenerator {
     target_dir: PathBuf,
+    dry_run: bool,
+    force: bool,
 }
 
 impl ConfigGenerator {
+    #[allow(dead_code)]
     pub fn new(target_dir: PathBuf) -> Self {
-        Self { target_dir }
+        Self {
+            target_dir,
+            dry_run: false,
+            force: false,
+        }
+    }
+
+    pub fn with_options(target_dir: PathBuf, dry_run: bool, force: bool) -> Self {
+        Self {
+            target_dir,
+            dry_run,
+            force,
+        }
     }
 
     pub async fn detect_project_type(&self) -> Result<ProjectType, ZackstrapError> {
@@ -103,7 +118,7 @@ impl ConfigGenerator {
         // TODO: Implement interactive setup
         println!("🎯 Interactive setup not yet implemented, generating basic configuration...");
 
-        self.generate_basic(false, false).await?;
+        self.generate_basic(false).await?;
 
         Ok(())
     }

--- a/src/generators/node.rs
+++ b/src/generators/node.rs
@@ -7,10 +7,7 @@ impl super::ConfigGenerator {
         self.generate_node_with_template("default").await
     }
 
-    pub async fn generate_node_with_template(
-        &self,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    pub async fn generate_node_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
         // Generate basic configs first
         self.generate_basic_with_template(false, template).await?;
 
@@ -85,7 +82,8 @@ impl super::ConfigGenerator {
 "#
             }
         };
-        self.emit_file(".eslintrc.json", content, false, false).await
+        self.emit_file(".eslintrc.json", content, false, false)
+            .await
     }
 
     async fn generate_node_package_json(&self, template: &str) -> Result<(), ZackstrapError> {

--- a/src/generators/node.rs
+++ b/src/generators/node.rs
@@ -1,58 +1,36 @@
-use super::common::FileGenerator;
 use crate::config::PackageJson;
 use crate::error::ZackstrapError;
 
 impl super::ConfigGenerator {
     #[allow(dead_code)]
-    pub async fn generate_node(&self, force: bool) -> Result<(), ZackstrapError> {
-        self.generate_node_with_template(force, "default").await
+    pub async fn generate_node(&self) -> Result<(), ZackstrapError> {
+        self.generate_node_with_template("default").await
     }
 
     pub async fn generate_node_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         // Generate basic configs first
-        self.generate_basic_with_template(force, false, template)
-            .await?;
+        self.generate_basic_with_template(false, template).await?;
 
         // Generate Node.js-specific configs
-        self.generate_nvmrc(force).await?;
-        self.generate_eslint_config(force, template).await?;
-        self.generate_node_package_json(force, template).await?;
+        self.generate_nvmrc().await?;
+        self.generate_eslint_config(template).await?;
+        self.generate_node_package_json(template).await?;
 
         // Overwrite the basic justfile with Node.js-specific one
-        self.generate_node_justfile(true, template).await?;
+        self.generate_node_justfile(template).await?;
 
         Ok(())
     }
 
-    pub async fn dry_run_node_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
-        println!("  📝 Would generate .editorconfig");
-        println!("  🎨 Would generate .prettierrc (template: {})", template);
-        println!("  🔧 Would generate justfile");
-        println!("  🟢 Would generate .nvmrc (20)");
-        println!("  🔍 Would generate .eslintrc.js (template: {})", template);
-        println!("  📦 Would generate package.json (template: {})", template);
-        println!(
-            "  🔧 Would generate Node.js justfile (template: {})",
-            template
-        );
-        Ok(())
-    }
-
-    async fn generate_nvmrc(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_nvmrc(&self) -> Result<(), ZackstrapError> {
         let content = "20\n";
-        self.write_file_if_not_exists(".nvmrc", content, force, false)
-            .await
+        self.emit_file(".nvmrc", content, false, false).await
     }
 
-    async fn generate_eslint_config(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_eslint_config(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "express" => {
                 r#"{
@@ -107,26 +85,16 @@ impl super::ConfigGenerator {
 "#
             }
         };
-        self.write_file_if_not_exists(".eslintrc.json", content, force, false)
-            .await
+        self.emit_file(".eslintrc.json", content, false, false).await
     }
 
-    async fn generate_node_package_json(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_node_package_json(&self, template: &str) -> Result<(), ZackstrapError> {
         let package_json = PackageJson::from_template(template);
         let content = package_json.to_string();
-        self.write_file_if_not_exists("package.json", &content, force, false)
-            .await
+        self.emit_file("package.json", &content, false, false).await
     }
 
-    async fn generate_node_justfile(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_node_justfile(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "express" => {
                 r#"# Express.js project justfile
@@ -240,7 +208,6 @@ build:
 "#
             }
         };
-        self.write_file_if_not_exists("justfile", content, force, false)
-            .await
+        self.emit_file("justfile", content, false, true).await
     }
 }

--- a/src/generators/python.rs
+++ b/src/generators/python.rs
@@ -1,62 +1,37 @@
-use super::common::FileGenerator;
 use crate::error::ZackstrapError;
 
 impl super::ConfigGenerator {
     #[allow(dead_code)]
-    pub async fn generate_python(&self, force: bool) -> Result<(), ZackstrapError> {
-        self.generate_python_with_template(force, "default").await
+    pub async fn generate_python(&self) -> Result<(), ZackstrapError> {
+        self.generate_python_with_template("default").await
     }
 
     pub async fn generate_python_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         // Generate basic configs first
-        self.generate_basic_with_template(force, false, template)
-            .await?;
+        self.generate_basic_with_template(false, template).await?;
 
         // Generate Python-specific configs
-        self.generate_python_version(force).await?;
-        self.generate_pyproject_toml(force, template).await?;
-        self.generate_flake8_config(force).await?;
-        self.generate_requirements_dev(force).await?;
+        self.generate_python_version().await?;
+        self.generate_pyproject_toml(template).await?;
+        self.generate_flake8_config().await?;
+        self.generate_requirements_dev().await?;
 
         // Overwrite the basic justfile with Python-specific one
-        self.generate_python_justfile(true, template).await?;
+        self.generate_python_justfile(template).await?;
 
         Ok(())
     }
 
-    pub async fn dry_run_python_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
-        println!("  📝 Would generate .editorconfig");
-        println!("  🎨 Would generate .prettierrc (template: {})", template);
-        println!("  🔧 Would generate justfile");
-        println!("  🐍 Would generate .python-version (3.12)");
-        println!(
-            "  📋 Would generate pyproject.toml (template: {})",
-            template
-        );
-        println!("  🔍 Would generate .flake8");
-        println!("  📦 Would generate requirements-dev.txt");
-        println!(
-            "  🔧 Would generate Python justfile (template: {})",
-            template
-        );
-        Ok(())
-    }
-
-    async fn generate_python_version(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_python_version(&self) -> Result<(), ZackstrapError> {
         let content = "3.12\n";
-        self.write_file_if_not_exists(".python-version", content, force, false)
+        self.emit_file(".python-version", content, false, false)
             .await
     }
 
-    async fn generate_pyproject_toml(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_pyproject_toml(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "django" => {
                 r#"[build-system]
@@ -184,21 +159,20 @@ strict = true
 "#
             }
         };
-        self.write_file_if_not_exists("pyproject.toml", content, force, false)
+        self.emit_file("pyproject.toml", content, false, false)
             .await
     }
 
-    async fn generate_flake8_config(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_flake8_config(&self) -> Result<(), ZackstrapError> {
         let content = r#"[flake8]
 max-line-length = 88
 extend-ignore = E203, W503
 exclude = .git,__pycache__,build,dist,.venv,venv
 "#;
-        self.write_file_if_not_exists(".flake8", content, force, false)
-            .await
+        self.emit_file(".flake8", content, false, false).await
     }
 
-    async fn generate_requirements_dev(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_requirements_dev(&self) -> Result<(), ZackstrapError> {
         let content = r#"# Development dependencies
 pytest==7.4.4
 black==23.12.1
@@ -206,15 +180,11 @@ flake8==6.1.0
 mypy==1.8.0
 pytest-cov==4.1.0
 "#;
-        self.write_file_if_not_exists("requirements-dev.txt", content, force, false)
+        self.emit_file("requirements-dev.txt", content, false, false)
             .await
     }
 
-    async fn generate_python_justfile(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_python_justfile(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "django" => {
                 r#"# Django project justfile
@@ -311,7 +281,6 @@ install:
 "#
             }
         };
-        self.write_file_if_not_exists("justfile", content, force, false)
-            .await
+        self.emit_file("justfile", content, false, true).await
     }
 }

--- a/src/generators/ruby.rs
+++ b/src/generators/ruby.rs
@@ -7,18 +7,14 @@ impl super::ConfigGenerator {
         self.generate_ruby_with_template("default").await
     }
 
-    pub async fn generate_ruby_with_template(
-        &self,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    pub async fn generate_ruby_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
         // Generate basic configs first (includes justfile)
         self.generate_basic_with_template(false, template).await?;
 
         // Generate Ruby-specific configs
         self.generate_ruby_version().await?;
         self.generate_node_version().await?;
-        self.generate_rubocop_config_with_template(template)
-            .await?;
+        self.generate_rubocop_config_with_template(template).await?;
         self.generate_package_json_with_template(template).await?;
 
         // Overwrite the basic justfile with Ruby-specific one

--- a/src/generators/ruby.rs
+++ b/src/generators/ruby.rs
@@ -1,63 +1,44 @@
-use super::common::FileGenerator;
 use crate::config::PackageJson;
 use crate::error::ZackstrapError;
 
 impl super::ConfigGenerator {
     #[allow(dead_code)]
-    pub async fn generate_ruby(&self, force: bool) -> Result<(), ZackstrapError> {
-        self.generate_ruby_with_template(force, "default").await
+    pub async fn generate_ruby(&self) -> Result<(), ZackstrapError> {
+        self.generate_ruby_with_template("default").await
     }
 
     pub async fn generate_ruby_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         // Generate basic configs first (includes justfile)
-        self.generate_basic_with_template(force, false, template)
-            .await?;
+        self.generate_basic_with_template(false, template).await?;
 
         // Generate Ruby-specific configs
-        self.generate_ruby_version(force).await?;
-        self.generate_node_version(force).await?;
-        self.generate_rubocop_config_with_template(force, template)
+        self.generate_ruby_version().await?;
+        self.generate_node_version().await?;
+        self.generate_rubocop_config_with_template(template)
             .await?;
-        self.generate_package_json_with_template(force, template)
-            .await?;
+        self.generate_package_json_with_template(template).await?;
 
         // Overwrite the basic justfile with Ruby-specific one
-        self.generate_ruby_justfile(true, template).await?;
+        self.generate_ruby_justfile(template).await?;
 
         Ok(())
     }
 
-    pub async fn dry_run_ruby_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
-        println!("  📝 Would generate .editorconfig");
-        println!("  🎨 Would generate .prettierrc (template: {})", template);
-        println!("  🔧 Would generate justfile");
-        println!("  💎 Would generate .ruby-version (3.3.0)");
-        println!("  🟢 Would generate .node-version (24)");
-        println!("  🔍 Would generate .rubocop.yml (template: {})", template);
-        println!("  📦 Would generate package.json (template: {})", template);
-        println!("  🔧 Would generate Ruby justfile (template: {})", template);
-        Ok(())
+    async fn generate_ruby_version(&self) -> Result<(), ZackstrapError> {
+        let content = "3.4.9\n";
+        self.emit_file(".ruby-version", content, false, false).await
     }
 
-    async fn generate_ruby_version(&self, force: bool) -> Result<(), ZackstrapError> {
-        let content = "3.3.0\n";
-        self.write_file_if_not_exists(".ruby-version", content, force, false)
-            .await
-    }
-
-    async fn generate_node_version(&self, force: bool) -> Result<(), ZackstrapError> {
-        let content = "24\n";
-        self.write_file_if_not_exists(".node-version", content, force, false)
-            .await
+    async fn generate_node_version(&self) -> Result<(), ZackstrapError> {
+        let content = "25.9.0\n";
+        self.emit_file(".node-version", content, false, false).await
     }
 
     async fn generate_rubocop_config_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         let content = match template {
@@ -148,13 +129,11 @@ Layout/LineLength:
 "#
             }
         };
-        self.write_file_if_not_exists(".rubocop.yml", content, force, false)
-            .await
+        self.emit_file(".rubocop.yml", content, false, false).await
     }
 
     async fn generate_package_json_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         let package_json = match template {
@@ -162,15 +141,10 @@ Layout/LineLength:
             _ => PackageJson::default(),
         };
         let content = package_json.to_string();
-        self.write_file_if_not_exists("package.json", &content, force, false)
-            .await
+        self.emit_file("package.json", &content, false, false).await
     }
 
-    async fn generate_ruby_justfile(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_ruby_justfile(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "rails" => {
                 r#"# Rails project justfile
@@ -290,7 +264,6 @@ install:
 "#
             }
         };
-        self.write_file_if_not_exists("justfile", content, force, false)
-            .await
+        self.emit_file("justfile", content, false, true).await
     }
 }

--- a/src/generators/rust.rs
+++ b/src/generators/rust.rs
@@ -1,44 +1,30 @@
-use super::common::FileGenerator;
 use crate::error::ZackstrapError;
 
 impl super::ConfigGenerator {
     #[allow(dead_code)]
-    pub async fn generate_rust(&self, force: bool) -> Result<(), ZackstrapError> {
-        self.generate_rust_with_template(force, "default").await
+    pub async fn generate_rust(&self) -> Result<(), ZackstrapError> {
+        self.generate_rust_with_template("default").await
     }
 
     pub async fn generate_rust_with_template(
         &self,
-        force: bool,
         template: &str,
     ) -> Result<(), ZackstrapError> {
         // Generate basic configs first
-        self.generate_basic_with_template(force, false, template)
-            .await?;
+        self.generate_basic_with_template(false, template).await?;
 
         // Generate Rust-specific configs
-        self.generate_rustfmt_config(force).await?;
-        self.generate_clippy_config(force).await?;
-        self.generate_cargo_config(force).await?;
+        self.generate_rustfmt_config().await?;
+        self.generate_clippy_config().await?;
+        self.generate_cargo_config().await?;
 
         // Overwrite the basic justfile with Rust-specific one
-        self.generate_rust_justfile(true, template).await?;
+        self.generate_rust_justfile(template).await?;
 
         Ok(())
     }
 
-    pub async fn dry_run_rust_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
-        println!("  📝 Would generate .editorconfig");
-        println!("  🎨 Would generate .prettierrc (template: {})", template);
-        println!("  🔧 Would generate justfile");
-        println!("  🦀 Would generate rustfmt.toml");
-        println!("  🔍 Would generate .clippy.toml");
-        println!("  📦 Would generate .cargo/config.toml");
-        println!("  🔧 Would generate Rust justfile (template: {})", template);
-        Ok(())
-    }
-
-    async fn generate_rustfmt_config(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_rustfmt_config(&self) -> Result<(), ZackstrapError> {
         let content = r#"# Rustfmt configuration
 edition = "2021"
 max_width = 100
@@ -46,11 +32,10 @@ tab_spaces = 2
 newline_style = "Unix"
 use_small_heuristics = "Default"
 "#;
-        self.write_file_if_not_exists("rustfmt.toml", content, force, false)
-            .await
+        self.emit_file("rustfmt.toml", content, false, false).await
     }
 
-    async fn generate_clippy_config(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_clippy_config(&self) -> Result<(), ZackstrapError> {
         let content = r#"# Clippy configuration
 # Threshold settings for common lints
 
@@ -62,11 +47,10 @@ enum-variant-name-threshold = 4
 max-struct-bools = 3
 max-fn-params-bools = 3
 "#;
-        self.write_file_if_not_exists(".clippy.toml", content, force, false)
-            .await
+        self.emit_file(".clippy.toml", content, false, false).await
     }
 
-    async fn generate_cargo_config(&self, force: bool) -> Result<(), ZackstrapError> {
+    async fn generate_cargo_config(&self) -> Result<(), ZackstrapError> {
         let content = r#"[build]
 # Set the target directory
 target = "target"
@@ -99,15 +83,11 @@ debug = false
 lto = true
 codegen-units = 1
 "#;
-        self.write_file_if_not_exists(".cargo/config.toml", content, force, false)
+        self.emit_file(".cargo/config.toml", content, false, false)
             .await
     }
 
-    async fn generate_rust_justfile(
-        &self,
-        force: bool,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    async fn generate_rust_justfile(&self, template: &str) -> Result<(), ZackstrapError> {
         let content = match template {
             "web" => {
                 r#"# Rust web project justfile
@@ -259,7 +239,6 @@ install:
 "#
             }
         };
-        self.write_file_if_not_exists("justfile", content, force, false)
-            .await
+        self.emit_file("justfile", content, false, true).await
     }
 }

--- a/src/generators/rust.rs
+++ b/src/generators/rust.rs
@@ -6,10 +6,7 @@ impl super::ConfigGenerator {
         self.generate_rust_with_template("default").await
     }
 
-    pub async fn generate_rust_with_template(
-        &self,
-        template: &str,
-    ) -> Result<(), ZackstrapError> {
+    pub async fn generate_rust_with_template(&self, template: &str) -> Result<(), ZackstrapError> {
         // Generate basic configs first
         self.generate_basic_with_template(false, template).await?;
 

--- a/tests/fail_on_exists_tests.rs
+++ b/tests/fail_on_exists_tests.rs
@@ -7,11 +7,11 @@ async fn test_fail_on_exists_basic_project() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // First generation should succeed
-    let result = generator.generate_basic(false, true).await;
+    let result = generator.generate_basic(true).await;
     assert!(result.is_ok());
 
     // Second generation with fail_on_exists=true should fail
-    let result = generator.generate_basic(false, true).await;
+    let result = generator.generate_basic(true).await;
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
@@ -19,7 +19,7 @@ async fn test_fail_on_exists_basic_project() {
     ));
 
     // Third generation with fail_on_exists=false should succeed
-    let result = generator.generate_basic(false, false).await;
+    let result = generator.generate_basic(false).await;
     assert!(result.is_ok());
 }
 
@@ -29,11 +29,12 @@ async fn test_fail_on_exists_with_force() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // First generation
-    let result = generator.generate_basic(false, true).await;
+    let result = generator.generate_basic(true).await;
     assert!(result.is_ok());
 
     // Second generation with force=true should succeed even with fail_on_exists=true
-    let result = generator.generate_basic(true, true).await;
+    let force_generator = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
+    let result = force_generator.generate_basic(true).await;
     assert!(result.is_ok());
 }
 
@@ -44,13 +45,13 @@ async fn test_fail_on_exists_ruby_project() {
 
     // First generation should succeed
     let result = generator
-        .generate_ruby_with_template(false, "default")
+        .generate_ruby_with_template("default")
         .await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
     let result = generator
-        .generate_ruby_with_template(false, "default")
+        .generate_ruby_with_template("default")
         .await;
     assert!(result.is_ok());
 }
@@ -62,13 +63,13 @@ async fn test_fail_on_exists_python_project() {
 
     // First generation should succeed
     let result = generator
-        .generate_python_with_template(false, "default")
+        .generate_python_with_template("default")
         .await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
     let result = generator
-        .generate_python_with_template(false, "default")
+        .generate_python_with_template("default")
         .await;
     assert!(result.is_ok());
 }
@@ -80,13 +81,13 @@ async fn test_fail_on_exists_node_project() {
 
     // First generation should succeed
     let result = generator
-        .generate_node_with_template(false, "default")
+        .generate_node_with_template("default")
         .await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
     let result = generator
-        .generate_node_with_template(false, "default")
+        .generate_node_with_template("default")
         .await;
     assert!(result.is_ok());
 }
@@ -97,11 +98,11 @@ async fn test_fail_on_exists_go_project() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // First generation should succeed
-    let result = generator.generate_go_with_template(false, "default").await;
+    let result = generator.generate_go_with_template("default").await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
-    let result = generator.generate_go_with_template(false, "default").await;
+    let result = generator.generate_go_with_template("default").await;
     assert!(result.is_ok());
 }
 
@@ -112,13 +113,13 @@ async fn test_fail_on_exists_rust_project() {
 
     // First generation should succeed
     let result = generator
-        .generate_rust_with_template(false, "default")
+        .generate_rust_with_template("default")
         .await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
     let result = generator
-        .generate_rust_with_template(false, "default")
+        .generate_rust_with_template("default")
         .await;
     assert!(result.is_ok());
 }
@@ -129,11 +130,11 @@ async fn test_fail_on_exists_individual_files() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Test individual file generation with fail_on_exists=true
-    let result = generator.generate_editor_config(false, true).await;
+    let result = generator.generate_editor_config(true).await;
     assert!(result.is_ok());
 
     // Second generation should fail
-    let result = generator.generate_editor_config(false, true).await;
+    let result = generator.generate_editor_config(true).await;
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
@@ -141,7 +142,7 @@ async fn test_fail_on_exists_individual_files() {
     ));
 
     // With fail_on_exists=false should succeed
-    let result = generator.generate_editor_config(false, false).await;
+    let result = generator.generate_editor_config(false).await;
     assert!(result.is_ok());
 }
 
@@ -156,7 +157,7 @@ async fn test_fail_on_exists_with_templates() {
     for template in templates {
         // First generation should succeed
         let result = generator
-            .generate_basic_with_template(false, true, template)
+            .generate_basic_with_template(true, template)
             .await;
         assert!(result.is_ok(), "Failed for template: {}", template);
 
@@ -170,14 +171,15 @@ async fn test_fail_on_exists_with_templates() {
 #[tokio::test]
 async fn test_fail_on_exists_edge_cases() {
     let temp_dir = TempDir::new().unwrap();
-    let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Test with force=true and fail_on_exists=true
-    let result = generator.generate_basic(true, true).await;
+    let force_generator = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
+    let result = force_generator.generate_basic(true).await;
     assert!(result.is_ok());
 
     // Test with force=false and fail_on_exists=false
-    let result = generator.generate_basic(false, false).await;
+    let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
+    let result = generator.generate_basic(false).await;
     assert!(result.is_ok());
 }
 
@@ -205,7 +207,7 @@ async fn test_fail_on_exists_file_specific_behavior() {
         std::fs::write(&file_path, "test content").unwrap();
 
         // Try to generate with fail_on_exists=true, should fail
-        let result = generator.generate_basic(false, true).await;
+        let result = generator.generate_basic(true).await;
         assert!(result.is_err());
 
         // Clean up
@@ -219,12 +221,12 @@ async fn test_fail_on_exists_language_specific_overrides() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Generate basic project first
-    let result = generator.generate_basic(false, true).await;
+    let result = generator.generate_basic(true).await;
     assert!(result.is_ok());
 
     // Now generate Ruby project - should succeed because it sets fail_on_exists=false
     let result = generator
-        .generate_ruby_with_template(false, "default")
+        .generate_ruby_with_template("default")
         .await;
     assert!(result.is_ok());
 
@@ -240,26 +242,27 @@ async fn test_fail_on_exists_mixed_scenarios() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Scenario 1: Basic project with fail_on_exists=true
-    let result = generator.generate_basic(false, true).await;
+    let result = generator.generate_basic(true).await;
     assert!(result.is_ok());
 
     // Scenario 2: Try to generate basic again with fail_on_exists=true (should fail)
-    let result = generator.generate_basic(false, true).await;
+    let result = generator.generate_basic(true).await;
     assert!(result.is_err());
 
     // Scenario 3: Generate Python project (should succeed, sets fail_on_exists=false)
     let result = generator
-        .generate_python_with_template(false, "default")
+        .generate_python_with_template("default")
         .await;
     assert!(result.is_ok());
 
     // Scenario 4: Generate Python again (should succeed)
     let result = generator
-        .generate_python_with_template(false, "default")
+        .generate_python_with_template("default")
         .await;
     assert!(result.is_ok());
 
     // Scenario 5: Try basic again with force=true (should succeed)
-    let result = generator.generate_basic(true, true).await;
+    let force_generator = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
+    let result = force_generator.generate_basic(true).await;
     assert!(result.is_ok());
 }

--- a/tests/fail_on_exists_tests.rs
+++ b/tests/fail_on_exists_tests.rs
@@ -44,15 +44,11 @@ async fn test_fail_on_exists_ruby_project() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // First generation should succeed
-    let result = generator
-        .generate_ruby_with_template("default")
-        .await;
+    let result = generator.generate_ruby_with_template("default").await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
-    let result = generator
-        .generate_ruby_with_template("default")
-        .await;
+    let result = generator.generate_ruby_with_template("default").await;
     assert!(result.is_ok());
 }
 
@@ -62,15 +58,11 @@ async fn test_fail_on_exists_python_project() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // First generation should succeed
-    let result = generator
-        .generate_python_with_template("default")
-        .await;
+    let result = generator.generate_python_with_template("default").await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
-    let result = generator
-        .generate_python_with_template("default")
-        .await;
+    let result = generator.generate_python_with_template("default").await;
     assert!(result.is_ok());
 }
 
@@ -80,15 +72,11 @@ async fn test_fail_on_exists_node_project() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // First generation should succeed
-    let result = generator
-        .generate_node_with_template("default")
-        .await;
+    let result = generator.generate_node_with_template("default").await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
-    let result = generator
-        .generate_node_with_template("default")
-        .await;
+    let result = generator.generate_node_with_template("default").await;
     assert!(result.is_ok());
 }
 
@@ -112,15 +100,11 @@ async fn test_fail_on_exists_rust_project() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // First generation should succeed
-    let result = generator
-        .generate_rust_with_template("default")
-        .await;
+    let result = generator.generate_rust_with_template("default").await;
     assert!(result.is_ok());
 
     // Second generation should succeed (fail_on_exists=false for language projects)
-    let result = generator
-        .generate_rust_with_template("default")
-        .await;
+    let result = generator.generate_rust_with_template("default").await;
     assert!(result.is_ok());
 }
 
@@ -156,9 +140,7 @@ async fn test_fail_on_exists_with_templates() {
 
     for template in templates {
         // First generation should succeed
-        let result = generator
-            .generate_basic_with_template(true, template)
-            .await;
+        let result = generator.generate_basic_with_template(true, template).await;
         assert!(result.is_ok(), "Failed for template: {}", template);
 
         // Clean up for next iteration
@@ -225,9 +207,7 @@ async fn test_fail_on_exists_language_specific_overrides() {
     assert!(result.is_ok());
 
     // Now generate Ruby project - should succeed because it sets fail_on_exists=false
-    let result = generator
-        .generate_ruby_with_template("default")
-        .await;
+    let result = generator.generate_ruby_with_template("default").await;
     assert!(result.is_ok());
 
     // Verify that Ruby-specific files were created
@@ -250,15 +230,11 @@ async fn test_fail_on_exists_mixed_scenarios() {
     assert!(result.is_err());
 
     // Scenario 3: Generate Python project (should succeed, sets fail_on_exists=false)
-    let result = generator
-        .generate_python_with_template("default")
-        .await;
+    let result = generator.generate_python_with_template("default").await;
     assert!(result.is_ok());
 
     // Scenario 4: Generate Python again (should succeed)
-    let result = generator
-        .generate_python_with_template("default")
-        .await;
+    let result = generator.generate_python_with_template("default").await;
     assert!(result.is_ok());
 
     // Scenario 5: Try basic again with force=true (should succeed)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,7 +8,7 @@ async fn test_generate_basic_config() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Test basic generation
-    generator.generate_basic(false, true).await.unwrap();
+    generator.generate_basic(true).await.unwrap();
 
     // Verify files were created
     temp_dir
@@ -34,7 +34,7 @@ async fn test_generate_ruby_config() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Test Ruby generation
-    generator.generate_ruby(false).await.unwrap();
+    generator.generate_ruby().await.unwrap();
 
     // Verify all files were created
     temp_dir
@@ -57,10 +57,10 @@ async fn test_generate_ruby_config() {
         .assert(predicates::path::exists());
     // Verify Ruby-specific content
     let ruby_version = std::fs::read_to_string(temp_dir.child(".ruby-version").path()).unwrap();
-    assert_eq!(ruby_version.trim(), "3.3.0");
+    assert_eq!(ruby_version.trim(), "3.4.9");
 
     let node_version = std::fs::read_to_string(temp_dir.child(".node-version").path()).unwrap();
-    assert_eq!(node_version.trim(), "24");
+    assert_eq!(node_version.trim(), "25.9.0");
 
     let package_json = std::fs::read_to_string(temp_dir.child("package.json").path()).unwrap();
     assert!(package_json.contains("prettier-plugin-ruby"));
@@ -78,7 +78,7 @@ async fn test_generate_python_config() {
 
     // Test Python generation
     generator
-        .generate_python_with_template(false, "default")
+        .generate_python_with_template("default")
         .await
         .unwrap();
 
@@ -128,7 +128,7 @@ async fn test_generate_python_config_with_templates() {
 
     // Test Django template
     generator
-        .generate_python_with_template(false, "django")
+        .generate_python_with_template("django")
         .await
         .unwrap();
     let pyproject_toml = std::fs::read_to_string(temp_dir.child("pyproject.toml").path()).unwrap();
@@ -143,7 +143,7 @@ async fn test_generate_python_config_with_templates() {
     std::fs::remove_file(temp_dir.child(".flake8").path()).unwrap();
     std::fs::remove_file(temp_dir.child("requirements-dev.txt").path()).unwrap();
     generator
-        .generate_python_with_template(false, "flask")
+        .generate_python_with_template("flask")
         .await
         .unwrap();
     let pyproject_toml = std::fs::read_to_string(temp_dir.child("pyproject.toml").path()).unwrap();
@@ -157,7 +157,7 @@ async fn test_generate_node_config() {
 
     // Test Node.js generation
     generator
-        .generate_node_with_template(false, "default")
+        .generate_node_with_template("default")
         .await
         .unwrap();
 
@@ -197,7 +197,7 @@ async fn test_generate_node_config_with_templates() {
 
     // Test Express template — server-side, so no "browser" env
     generator
-        .generate_node_with_template(false, "express")
+        .generate_node_with_template("express")
         .await
         .unwrap();
     let eslint_config = std::fs::read_to_string(temp_dir.child(".eslintrc.json").path()).unwrap();
@@ -213,7 +213,7 @@ async fn test_generate_node_config_with_templates() {
     std::fs::remove_file(temp_dir.child(".prettierrc").path()).unwrap();
     std::fs::remove_file(temp_dir.child(".nvmrc").path()).unwrap();
     generator
-        .generate_node_with_template(false, "react")
+        .generate_node_with_template("react")
         .await
         .unwrap();
     let eslint_config = std::fs::read_to_string(temp_dir.child(".eslintrc.json").path()).unwrap();
@@ -229,7 +229,7 @@ async fn test_generate_go_config() {
 
     // Test Go generation
     generator
-        .generate_go_with_template(false, "default")
+        .generate_go_with_template("default")
         .await
         .unwrap();
 
@@ -264,7 +264,7 @@ async fn test_generate_go_config_with_templates() {
 
     // Test web template
     generator
-        .generate_go_with_template(false, "web")
+        .generate_go_with_template("web")
         .await
         .unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
@@ -277,8 +277,9 @@ async fn test_generate_go_config_with_templates() {
     std::fs::remove_file(temp_dir.child("go.mod").path()).unwrap();
     std::fs::remove_file(temp_dir.child(".golangci.yml").path()).unwrap();
     // Note: .gitignore is updated, not created, so we don't remove it
-    generator
-        .generate_go_with_template(true, "cli")
+    let force_generator = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
+    force_generator
+        .generate_go_with_template("cli")
         .await
         .unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
@@ -292,7 +293,7 @@ async fn test_generate_rust_config() {
 
     // Test Rust generation
     generator
-        .generate_rust_with_template(false, "default")
+        .generate_rust_with_template("default")
         .await
         .unwrap();
 
@@ -330,7 +331,7 @@ async fn test_generate_rust_config_with_templates() {
 
     // Test web template
     generator
-        .generate_rust_with_template(false, "web")
+        .generate_rust_with_template("web")
         .await
         .unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
@@ -344,7 +345,7 @@ async fn test_generate_rust_config_with_templates() {
     std::fs::remove_file(temp_dir.child(".clippy.toml").path()).unwrap();
     std::fs::remove_dir_all(temp_dir.child(".cargo").path()).unwrap();
     generator
-        .generate_rust_with_template(false, "cli")
+        .generate_rust_with_template("cli")
         .await
         .unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
@@ -358,7 +359,7 @@ async fn test_generate_bash_config() {
 
     // Test Bash generation
     generator
-        .generate_bash_with_template(false, "default")
+        .generate_bash_with_template("default")
         .await
         .unwrap();
 
@@ -395,7 +396,7 @@ async fn test_generate_bash_config_with_templates() {
 
     // Test devops template
     generator
-        .generate_bash_with_template(false, "devops")
+        .generate_bash_with_template("devops")
         .await
         .unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
@@ -408,7 +409,7 @@ async fn test_generate_bash_config_with_templates() {
     std::fs::remove_file(temp_dir.child(".prettierrc").path()).unwrap();
     std::fs::remove_file(temp_dir.child(".shellcheckrc").path()).unwrap();
     generator
-        .generate_bash_with_template(false, "cli")
+        .generate_bash_with_template("cli")
         .await
         .unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
@@ -470,32 +471,32 @@ async fn test_project_type_detection() {
 #[tokio::test]
 async fn test_dry_run_modes() {
     let temp_dir = TempDir::new().unwrap();
-    let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
+    let generator = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), true, false);
 
     // Test Python dry run
     generator
-        .dry_run_python_with_template("default")
+        .generate_python_with_template("default")
         .await
         .unwrap();
 
     // Test Node.js dry run
     generator
-        .dry_run_node_with_template("default")
+        .generate_node_with_template("default")
         .await
         .unwrap();
 
     // Test Go dry run
-    generator.dry_run_go_with_template("default").await.unwrap();
+    generator.generate_go_with_template("default").await.unwrap();
 
     // Test Rust dry run
     generator
-        .dry_run_rust_with_template("default")
+        .generate_rust_with_template("default")
         .await
         .unwrap();
 
     // Test Bash dry run
     generator
-        .dry_run_bash_with_template("default")
+        .generate_bash_with_template("default")
         .await
         .unwrap();
 
@@ -514,17 +515,18 @@ async fn test_force_overwrite_for_new_languages() {
 
     // Test Python force overwrite - language projects use fail_on_exists=false, so they succeed on second generation
     generator
-        .generate_python_with_template(false, "default")
+        .generate_python_with_template("default")
         .await
         .unwrap();
     // Second generation should succeed (fail_on_exists=false for language projects)
     let result = generator
-        .generate_python_with_template(false, "default")
+        .generate_python_with_template("default")
         .await;
     assert!(result.is_ok());
     // Force overwrite should also succeed
-    generator
-        .generate_python_with_template(true, "default")
+    let force_gen = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
+    force_gen
+        .generate_python_with_template("default")
         .await
         .unwrap();
 
@@ -536,17 +538,18 @@ async fn test_force_overwrite_for_new_languages() {
     let _ = std::fs::remove_file(temp_dir.child(".editorconfig").path());
     let _ = std::fs::remove_file(temp_dir.child(".prettierrc").path());
     generator
-        .generate_node_with_template(false, "default")
+        .generate_node_with_template("default")
         .await
         .unwrap();
     // Second generation should succeed (fail_on_exists=false for language projects)
     let result = generator
-        .generate_node_with_template(false, "default")
+        .generate_node_with_template("default")
         .await;
     assert!(result.is_ok());
     // Force overwrite should also succeed
-    generator
-        .generate_node_with_template(true, "default")
+    let force_gen2 = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
+    force_gen2
+        .generate_node_with_template("default")
         .await
         .unwrap();
 }
@@ -557,14 +560,15 @@ async fn test_force_overwrite() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Create initial config
-    generator.generate_basic(false, true).await.unwrap();
+    generator.generate_basic(true).await.unwrap();
 
     // Try to generate again without force - should fail
-    let result = generator.generate_basic(false, true).await;
+    let result = generator.generate_basic(true).await;
     assert!(result.is_err());
 
     // Generate with force - should succeed
-    generator.generate_basic(true, true).await.unwrap();
+    let force_generator = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
+    force_generator.generate_basic(true).await.unwrap();
 }
 
 #[tokio::test]
@@ -572,7 +576,7 @@ async fn test_editor_config_sections() {
     let temp_dir = TempDir::new().unwrap();
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
-    generator.generate_basic(false, true).await.unwrap();
+    generator.generate_basic(true).await.unwrap();
 
     let editor_config = std::fs::read_to_string(temp_dir.child(".editorconfig").path()).unwrap();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -263,10 +263,7 @@ async fn test_generate_go_config_with_templates() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Test web template
-    generator
-        .generate_go_with_template("web")
-        .await
-        .unwrap();
+    generator.generate_go_with_template("web").await.unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
     assert!(justfile.contains("go-web"));
 
@@ -330,10 +327,7 @@ async fn test_generate_rust_config_with_templates() {
     let generator = ConfigGenerator::new(temp_dir.path().to_path_buf());
 
     // Test web template
-    generator
-        .generate_rust_with_template("web")
-        .await
-        .unwrap();
+    generator.generate_rust_with_template("web").await.unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
     assert!(justfile.contains("cargo-web"));
 
@@ -344,10 +338,7 @@ async fn test_generate_rust_config_with_templates() {
     std::fs::remove_file(temp_dir.child("rustfmt.toml").path()).unwrap();
     std::fs::remove_file(temp_dir.child(".clippy.toml").path()).unwrap();
     std::fs::remove_dir_all(temp_dir.child(".cargo").path()).unwrap();
-    generator
-        .generate_rust_with_template("cli")
-        .await
-        .unwrap();
+    generator.generate_rust_with_template("cli").await.unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
     assert!(justfile.contains("cargo-cli"));
 }
@@ -408,10 +399,7 @@ async fn test_generate_bash_config_with_templates() {
     std::fs::remove_file(temp_dir.child(".editorconfig").path()).unwrap();
     std::fs::remove_file(temp_dir.child(".prettierrc").path()).unwrap();
     std::fs::remove_file(temp_dir.child(".shellcheckrc").path()).unwrap();
-    generator
-        .generate_bash_with_template("cli")
-        .await
-        .unwrap();
+    generator.generate_bash_with_template("cli").await.unwrap();
     let justfile = std::fs::read_to_string(temp_dir.child("justfile").path()).unwrap();
     assert!(justfile.contains("CLI"));
     assert!(justfile.contains("main.sh"));
@@ -486,7 +474,10 @@ async fn test_dry_run_modes() {
         .unwrap();
 
     // Test Go dry run
-    generator.generate_go_with_template("default").await.unwrap();
+    generator
+        .generate_go_with_template("default")
+        .await
+        .unwrap();
 
     // Test Rust dry run
     generator
@@ -519,9 +510,7 @@ async fn test_force_overwrite_for_new_languages() {
         .await
         .unwrap();
     // Second generation should succeed (fail_on_exists=false for language projects)
-    let result = generator
-        .generate_python_with_template("default")
-        .await;
+    let result = generator.generate_python_with_template("default").await;
     assert!(result.is_ok());
     // Force overwrite should also succeed
     let force_gen = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);
@@ -542,9 +531,7 @@ async fn test_force_overwrite_for_new_languages() {
         .await
         .unwrap();
     // Second generation should succeed (fail_on_exists=false for language projects)
-    let result = generator
-        .generate_node_with_template("default")
-        .await;
+    let result = generator.generate_node_with_template("default").await;
     assert!(result.is_ok());
     // Force overwrite should also succeed
     let force_gen2 = ConfigGenerator::with_options(temp_dir.path().to_path_buf(), false, true);


### PR DESCRIPTION
## Summary

- **Unified dry-run output**: Replaced 7 separate `dry_run_*_with_template` methods with a single `emit_file()` method on `ConfigGenerator` that transparently handles both real writes and dry-run preview
- **Dry-run now shows file content** with `[CREATE]`, `[SKIP]`, or `[OVERWRITE]` status based on file existence and force flags
- **Updated Ruby to 3.4.9** and **Node to 25.9.0**
- **Net -150 lines**: deleted `handle_auto_dry_run` and all per-generator dry-run methods

### How it works

`ConfigGenerator` now carries `dry_run` and `force` as struct fields. The `emit_file()` method checks these fields and either prints a colored preview or delegates to `write_file_if_not_exists`. Generators call `emit_file()` instead of `write_file_if_not_exists` directly, so dry-run can never drift from actual generation.

## Test plan

- [ ] `cargo test` — all 111 tests pass
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo run -- --dry-run ruby --template rails` — shows file content with status indicators
- [ ] `cargo run -- --dry-run ruby` — shows CREATE for new files
- [ ] `cargo run -- --dry-run --force ruby` — shows OVERWRITE for existing files