### PR TITLE
ci: standardize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,205 +1,160 @@
-name: Release and Publish
+name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: "Release type (will auto-bump version)"
-        required: true
-        default: "patch"
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
+  push:
+    branches: [main]
+    paths: [Cargo.toml]
 
 permissions:
-  actions: write
   contents: write
-  id-token: write
-  attestations: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CRATE_NAME: zackstrap
+  BIN_NAME: zackstrap
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Create Release
+  read-version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.bump.outputs.version }}
-
+      version: ${{ steps.ver.outputs.version }}
+      tag: ${{ steps.ver.outputs.tag }}
+      tag_exists: ${{ steps.ver.outputs.tag_exists }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-
-      - name: Configure Git
+          fetch-depth: 0
+      - id: ver
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          cache-all-crates: true
-
-      - name: Install cargo-edit
-        run: cargo install cargo-edit
-
-      - name: Bump version
-        id: bump
-        run: |
-          echo "Release type: '${{ github.event.inputs.release_type }}'"
-
-          # Read current version from Cargo.toml using grep and sed
-          current_version=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "Current version from Cargo.toml: $current_version"
-
-          if [ "${{ github.event.inputs.release_type }}" = "major" ]; then
-            new_version=$(echo $current_version | awk -F. '{print $1+1 ".0.0"}')
-          elif [ "${{ github.event.inputs.release_type }}" = "minor" ]; then
-            new_version=$(echo $current_version | awk -F. '{print $1 "." $2+1 ".0"}')
+          VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
           else
-            new_version=$(echo $current_version | awk -F. '{print $1 "." $2 "." $3+1}')
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
           fi
+          echo "Version: ${VERSION}, Tag: ${TAG}"
 
-          echo "Auto-bumped version: $new_version"
-          echo "version=$new_version" >> $GITHUB_OUTPUT
-          echo "Final version output: $new_version"
-
-      - name: Update Cargo.toml version
-        run: |
-          cargo set-version ${{ steps.bump.outputs.version }}
-
-      - name: Update Cargo.lock
-        run: cargo check
-
-      - name: Create changelog
-        run: |
-          echo "# Changelog for ${{ steps.bump.outputs.version }}" > CHANGELOG.md
-          echo "" >> CHANGELOG.md
-          echo "## [Unreleased]" >> CHANGELOG.md
-          echo "" >> CHANGELOG.md
-
-          # Get the previous tag or use initial commit
-          if git tag --sort=-version:refname | head -n1 | grep -q .; then
-            previous_tag=$(git tag --sort=-version:refname | head -n1)
-            echo "## Changes since $previous_tag" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-
-            # Get commits since last tag
-            commits=$(git log --oneline --no-merges "$previous_tag..HEAD" | head -20)
-            if [ -n "$commits" ]; then
-              echo "### Commits" >> CHANGELOG.md
-              echo "" >> CHANGELOG.md
-              echo "$commits" | while read -r commit; do
-                echo "- $commit" >> CHANGELOG.md
-              done
-              echo "" >> CHANGELOG.md
-            fi
-          else
-            echo "## Initial Release" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-            echo "### Features" >> CHANGELOG.md
-            echo "- Initial project setup" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-          fi
-
-      - name: Build release
-        run: cargo build --release
-
-      - name: Create release assets
-        run: |
-          mkdir -p release
-          cp target/release/zackstrap release/zackstrap-ubuntu
-          tar -czf release/zackstrap-ubuntu.tar.gz -C release zackstrap-ubuntu
-
-      - name: Generate artifact attestations
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-path: "${{ github.workspace }}/release/zackstrap-ubuntu.tar.gz"
-
-      - name: Commit and push changes
-        run: |
-          git add Cargo.toml Cargo.lock CHANGELOG.md
-          git commit -m "Bump version to ${{ steps.bump.outputs.version }}"
-          git tag -a "v${{ steps.bump.outputs.version }}" -m "Release v${{ steps.bump.outputs.version }}"
-          git push origin main
-          git push origin "v${{ steps.bump.outputs.version }}"
-
-      - name: Create GitHub Release
-        id: create_release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: "v${{ steps.bump.outputs.version }}"
-          name: "Release v${{ steps.bump.outputs.version }}"
-          body: |
-            ## Release v${{ steps.bump.outputs.version }}
-
-            This release includes the following changes since the previous version.
-
-            ### 📋 Changelog
-            See the [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) file for detailed information about this release.
-
-            ### 🚀 Installation
-
-            ```bash
-            cargo install zackstrap
-            ```
-
-            ### 📖 Usage
-
-            ```bash
-            zackstrap --help
-            ```
-
-            ### 🔗 Links
-            - [Repository](https://github.com/${{ github.repository }})
-            - [Documentation](https://docs.rs/zackstrap)
-            - [Issues](https://github.com/${{ github.repository }}/issues)
-          draft: false
-          prerelease: false
-          files: release/zackstrap-ubuntu.tar.gz
-
-  publish:
-    name: Publish to Crates.io
+  verify:
+    needs: read-version
+    if: needs.read-version.outputs.tag_exists == 'false'
     runs-on: ubuntu-latest
-    needs: release
-    if: success()
-
     steps:
-      - name: Wait for git push to propagate
-        run: |
-          echo "Waiting for git push to propagate..."
-          sleep 10
-          echo "Proceeding with checkout..."
-
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          ref: "main"
-          fetch-depth: 1
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - uses: extractions/setup-just@v2
+      - run: just release-check
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+  build:
+    needs: [read-version, verify]
+    if: needs.read-version.outputs.tag_exists == 'false'
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          cache-all-crates: true
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
-      - name: Verify version
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build
         run: |
-          echo "Verifying version before publishing..."
-          current_version=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "Current version in Cargo.toml: $current_version"
-          echo "Expected version from release job: ${{ needs.release.outputs.version }}"
-
-          if [ "$current_version" != "${{ needs.release.outputs.version }}" ]; then
-            echo "❌ Version mismatch! Expected ${{ needs.release.outputs.version }} but found $current_version"
-            exit 1
+          if [[ "${{ matrix.cross }}" == "true" ]]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
           fi
-          echo "✅ Version verified: $current_version"
 
-      - name: Publish to crates.io
-        run: cargo publish
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf "../../../${BIN_NAME}-${{ matrix.target }}.tar.gz" "${BIN_NAME}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BIN_NAME }}-${{ matrix.target }}
+          path: ${{ env.BIN_NAME }}-${{ matrix.target }}.tar.gz
+
+  release:
+    needs: [read-version, build]
+    if: needs.read-version.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum *.tar.gz > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create tag
+        run: |
+          git tag ${{ needs.read-version.outputs.tag }}
+          git push origin ${{ needs.read-version.outputs.tag }}
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.read-version.outputs.tag }}
+          generate_release_notes: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/SHA256SUMS.txt
+
+  publish-crate:
+    needs: [read-version, release]
+    if: needs.read-version.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check if already published
+        id: check
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://crates.io/api/v1/crates/${CRATE_NAME}/${{ needs.read-version.outputs.version }}")
+          if [[ "$STATUS" == "200" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Version already on crates.io — skipping"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish
+        if: steps.check.outputs.skip == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --allow-dirty

--- a/justfile
+++ b/justfile
@@ -4,8 +4,6 @@
 set dotenv-load := false
 
 version := `cargo get package.version 2>/dev/null || echo 'unknown'`
-os := `uname -s | tr '[:upper:]' '[:lower:]'`
-arch := `uname -m`
 
 # ─── Default ──────────────────────────────────────────────────────────
 
@@ -153,43 +151,57 @@ ci-test:
 
 # ─── Release ──────────────────────────────────────────────────────────
 
-# Bump version, tag, push, and publish to crates.io
-release LEVEL:
+# Release quality gate (fmt + clippy + test)
+release-check:
+    cargo fmt --check
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test
+
+# Preview what a release would do without changing anything
+release-dry-run LEVEL:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [[ "{{LEVEL}}" != "patch" && "{{LEVEL}}" != "minor" && "{{LEVEL}}" != "major" ]]; then
-        echo "Usage: just release [patch|minor|major]"
-        exit 1
+    if [[ ! "{{LEVEL}}" =~ ^(patch|minor|major)$ ]]; then
+        echo "Usage: just release-dry-run patch|minor|major"; exit 1
     fi
-    echo "Creating {{LEVEL}} release..."
-    cargo set-version --bump {{LEVEL}}
-    cargo check
-    git add Cargo.toml Cargo.lock
-    git commit -m "Bump version for {{LEVEL}} release"
-    VERSION="$(cargo get package.version)"
-    git tag -a "v${VERSION}" -m "Release v${VERSION}"
-    echo "Pushing to origin..."
-    git push origin main
-    git push origin "v${VERSION}"
-    echo "Publishing to crates.io..."
-    cargo publish
-    echo "Released v${VERSION}"
+    CURRENT=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+    echo "Current version: $CURRENT"
+    echo "Bump level: {{LEVEL}}"
+    just release-check
+    echo ""
+    echo "All checks passed. Run: just release {{LEVEL}}"
 
-# Build a distributable zipfile for the current platform
-dist:
+# Bump version, create release branch + PR (requires: cargo-set-version, gh)
+release LEVEL: release-check
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "Building release binary..."
-    cargo build --release
-    mkdir -p dist
-    cp target/release/zackstrap dist/
-    ZIPNAME="zackstrap-{{version}}-{{os}}-{{arch}}.zip"
-    cd dist && zip -r "$ZIPNAME" zackstrap
-    echo "dist/$ZIPNAME"
-
-# Dry-run a crates.io publish (validates packaging without uploading)
-publish-dry-run:
-    cargo publish --dry-run
+    if [[ ! "{{LEVEL}}" =~ ^(patch|minor|major)$ ]]; then
+        echo "Usage: just release patch|minor|major"; exit 1
+    fi
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Error: dirty working tree"; exit 1
+    fi
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$BRANCH" != "main" ]]; then
+        echo "Error: must be on main (currently on $BRANCH)"; exit 1
+    fi
+    git pull --ff-only origin main
+    cargo set-version --bump {{LEVEL}}
+    cargo check --quiet
+    VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+    git checkout -b "release/v${VERSION}"
+    git add Cargo.toml Cargo.lock
+    git commit -m "release: v${VERSION}"
+    git push -u origin "release/v${VERSION}"
+    gh pr create \
+        --title "release: v${VERSION}" \
+        --body "Bump to v${VERSION} ({{LEVEL}} release)" \
+        --base main
+    echo ""
+    echo "PR created. Next steps:"
+    echo "  gh pr checks           # watch CI"
+    echo "  gh pr merge --squash --delete-branch"
+    echo "  gh run watch           # watch release workflow"
 
 # ─── Cleanup ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replace old `workflow_dispatch` + local-tag-and-push release with the standardized PR-based flow
- Justfile: `release-check`, `release-dry-run`, `release` recipes (branch → PR → merge → CI handles tag/build/publish)
- release.yml: triggers on Cargo.toml push to main, idempotent tag guard, cross-builds 4 targets (linux x86/arm, macOS x86/arm), SHA256 checksums, crates.io publish with duplicate check
- Removed old `dist` and `publish-dry-run` recipes, cleaned unused `os`/`arch` justfile vars

## Test plan
- [x] `just release-dry-run patch` passes (111 tests, fmt clean, clippy clean)
- [x] `CARGO_REGISTRY_TOKEN` secret verified present
- [ ] Merge and verify release.yml triggers correctly on first real release